### PR TITLE
Removing debugging print statement in client.py

### DIFF
--- a/ecmwf/opendata/client.py
+++ b/ecmwf/opendata/client.py
@@ -285,7 +285,6 @@ class Client:
 
         for name, values in for_index.items():
             diff = set(values).difference(possible_values[name])
-            print(diff, sorted(possible_values[name]))
             for d in diff:
                 warning_once(
                     "No index entries for %s=%s",


### PR DESCRIPTION
Removing a print statement that clutters the output of the package. Seems to likely be a left over debug print.

Closes: https://github.com/ecmwf/ecmwf-opendata/issues/44