### PR TITLE
Add wheel to python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -84,4 +84,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python setup.py sdist
+        python -m build
         twine upload dist/*


### PR DESCRIPTION
Path of least resistance here is to simply modify the existing workflow to build a wheel