### PR TITLE
Publish wheels to PyPi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -77,11 +77,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        python setup.py sdist
+        python -m build
         twine upload dist/*


### PR DESCRIPTION
The issue with #57 was that build was not installed, this PR should fix it (inspired by https://github.com/ecmwf/covjsonkit/pull/69)