### PR TITLE
Update client to use 50r1 streams when requesting source=ecmwf-testdata

### DIFF
--- a/ecmwf/opendata/client.py
+++ b/ecmwf/opendata/client.py
@@ -194,7 +194,6 @@ class Client:
 
         if self.use_sas_token:
             result.urls = self._apply_sas_to_urls(result.urls)
-
         result.size = download(
             result.urls,
             target=result.target,
@@ -583,21 +582,32 @@ class Client:
         return (dict(**for_urls), dict(**for_index))
 
     def patch_stream(self, args):
-        URL_STREAM_MAPPING = {
-            ("oper", "06"): "scda",
-            ("oper", "18"): "scda",
-            ("wave", "06"): "scwv",
-            ("wave", "18"): "scwv",
-            #
-            ("oper", "ef"): "enfo",
-            ("wave", "ef"): "waef",
-            ("oper", "ep"): "enfo",
-            ("wave", "ep"): "waef",
-            ("scda", "ef"): "enfo",
-            ("scwv", "ef"): "waef",
-            ("scda", "ep"): "enfo",
-            ("scwv", "ep"): "waef",
-        }
+        # As of IFS Cycle 50r1, the 06/18 UTC runs are archived under stream=oper/wave
+        # rather than stream=scda/scwv. This new behaviour is used when source="ecmwf-testdata"
+        # until the operational upgrade is complete.
+        if self.source == "ecmwf-testdata":
+            URL_STREAM_MAPPING = {
+                ("oper", "ef"): "enfo",
+                ("wave", "ef"): "waef",
+                ("oper", "ep"): "enfo",
+                ("wave", "ep"): "waef",
+            }
+        else:
+            URL_STREAM_MAPPING = {
+                ("oper", "06"): "scda",
+                ("oper", "18"): "scda",
+                ("wave", "06"): "scwv",
+                ("wave", "18"): "scwv",
+                #
+                ("oper", "ef"): "enfo",
+                ("wave", "ef"): "waef",
+                ("oper", "ep"): "enfo",
+                ("wave", "ep"): "waef",
+                ("scda", "ef"): "enfo",
+                ("scwv", "ef"): "waef",
+                ("scda", "ep"): "enfo",
+                ("scwv", "ep"): "waef",
+            }
         stream, time, type = args["stream"], args["_H"], args["type"]
 
         if not self.infer_stream_keyword or args["model"] == "aifs-single":

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,13 +1,14 @@
 from ecmwf.opendata import Client
 
 
-def patch_stream(stream, time, type):
-    client = Client(infer_stream_keyword=True)
+def patch_stream(stream, time, type, source="ecmwf"):
+    client = Client(source=source, infer_stream_keyword=True)
     args = {"stream": stream, "_H": "%02d" % (time,), "type": type, "model": "ifs"}
     return client.patch_stream(args)
 
 
-def test_stream():
+def test_stream_legacy():
+    """Legacy behaviour (pre-IFS Cycle 50r1): 06/18 UTC runs use scda/scwv streams."""
     assert patch_stream("oper", 0, "fc") == "oper"
     assert patch_stream("oper", 6, "fc") == "scda"
     assert patch_stream("oper", 12, "fc") == "oper"
@@ -38,6 +39,60 @@ def test_stream():
     assert patch_stream("wave", 12, "ep") == "waef"
     assert patch_stream("wave", 18, "ep") == "waef"
 
+    # scda/scwv still map through to enfo/waef in legacy mode
+    assert patch_stream("scda", 6, "ef") == "enfo"
+    assert patch_stream("scda", 18, "ef") == "enfo"
+    assert patch_stream("scwv", 6, "ef") == "waef"
+    assert patch_stream("scwv", 18, "ef") == "waef"
+    assert patch_stream("scda", 6, "ep") == "enfo"
+    assert patch_stream("scda", 18, "ep") == "enfo"
+    assert patch_stream("scwv", 6, "ep") == "waef"
+    assert patch_stream("scwv", 18, "ep") == "waef"
+
+
+def test_stream_50r1():
+    """IFS Cycle 50r1 behaviour (source='ecmwf-testdata'): 06/18 UTC runs remain
+    under stream=oper/wave, with no scda/scwv streams."""
+    # 00/06/12/18 UTC all stay under oper for fc
+    assert patch_stream("oper", 0, "fc", source="ecmwf-testdata") == "oper"
+    assert patch_stream("oper", 6, "fc", source="ecmwf-testdata") == "oper"
+    assert patch_stream("oper", 12, "fc", source="ecmwf-testdata") == "oper"
+    assert patch_stream("oper", 18, "fc", source="ecmwf-testdata") == "oper"
+
+    # 00/06/12/18 UTC all stay under wave for fc
+    assert patch_stream("wave", 0, "fc", source="ecmwf-testdata") == "wave"
+    assert patch_stream("wave", 6, "fc", source="ecmwf-testdata") == "wave"
+    assert patch_stream("wave", 12, "fc", source="ecmwf-testdata") == "wave"
+    assert patch_stream("wave", 18, "fc", source="ecmwf-testdata") == "wave"
+
+    # ef type still maps oper -> enfo and wave -> waef
+    assert patch_stream("oper", 0, "ef", source="ecmwf-testdata") == "enfo"
+    assert patch_stream("oper", 6, "ef", source="ecmwf-testdata") == "enfo"
+    assert patch_stream("oper", 12, "ef", source="ecmwf-testdata") == "enfo"
+    assert patch_stream("oper", 18, "ef", source="ecmwf-testdata") == "enfo"
+
+    assert patch_stream("wave", 0, "ef", source="ecmwf-testdata") == "waef"
+    assert patch_stream("wave", 6, "ef", source="ecmwf-testdata") == "waef"
+    assert patch_stream("wave", 12, "ef", source="ecmwf-testdata") == "waef"
+    assert patch_stream("wave", 18, "ef", source="ecmwf-testdata") == "waef"
+
+    # ep type still maps oper -> enfo and wave -> waef
+    assert patch_stream("oper", 0, "ep", source="ecmwf-testdata") == "enfo"
+    assert patch_stream("oper", 6, "ep", source="ecmwf-testdata") == "enfo"
+    assert patch_stream("oper", 12, "ep", source="ecmwf-testdata") == "enfo"
+    assert patch_stream("oper", 18, "ep", source="ecmwf-testdata") == "enfo"
+
+    assert patch_stream("wave", 0, "ep", source="ecmwf-testdata") == "waef"
+    assert patch_stream("wave", 6, "ep", source="ecmwf-testdata") == "waef"
+    assert patch_stream("wave", 12, "ep", source="ecmwf-testdata") == "waef"
+    assert patch_stream("wave", 18, "ep", source="ecmwf-testdata") == "waef"
+
+
+# Keep the original test name as an alias so existing test runs aren't broken
+def test_stream():
+    test_stream_legacy()
+
 
 if __name__ == "__main__":
-    test_stream()
+    test_stream_legacy()
+    test_stream_50r1()


### PR DESCRIPTION
### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
