### PR TITLE
refactor: introduce source factory with defaults for range requests

### DIFF
--- a/ecmwf/opendata/__init__.py
+++ b/ecmwf/opendata/__init__.py
@@ -10,6 +10,6 @@
 
 from .client import Client
 
-__version__ = "0.3.29"
+__version__ = "0.3.30"
 
 __all__ = ["Client"]

--- a/ecmwf/opendata/client.py
+++ b/ecmwf/opendata/client.py
@@ -13,11 +13,11 @@ import itertools
 import json
 import logging
 import os
-import requests
-
 from collections import defaultdict
-from multiurl import download, robust
 from typing import Optional
+
+import requests
+from multiurl import download, robust
 
 from .date import (
     canonical_time,
@@ -28,8 +28,7 @@ from .date import (
     full_date,
 )
 from .sources import source_factory
-from .utils import warning_once, _show_attribution_message
-
+from .utils import _show_attribution_message, warning_once
 
 LOG = logging.getLogger(__name__)
 
@@ -75,12 +74,12 @@ class Client:
         sas_known_key="ecmwf",
         sas_custom_url=None,
         source_accept_ranges=None,
-        source_accept_multiple_ranges=None
+        source_accept_multiple_ranges=None,
     ):
         self.source = source_factory(
             name=source,
             accept_ranges=source_accept_ranges,
-            accept_multiple_ranges=source_accept_multiple_ranges
+            accept_multiple_ranges=source_accept_multiple_ranges,
         )
         self.model = model
         self.resol = resol
@@ -132,7 +131,7 @@ class Client:
         request: Optional[dict] = None,
         target: Optional[str] = None,
         use_index: bool = False,
-        **kwargs
+        **kwargs,
     ) -> Result:
         result = self._get_urls(request, target=target, use_index=use_index, **kwargs)
         if self.use_sas_token:
@@ -144,7 +143,7 @@ class Client:
             verify=self.verify,
             session=self.session,
             accept_ranges=self.source.accept_ranges,
-            accept_multiple_ranges=self.source.accept_multiple_ranges
+            accept_multiple_ranges=self.source.accept_multiple_ranges,
         )
         _show_attribution_message()
         return result

--- a/ecmwf/opendata/client.py
+++ b/ecmwf/opendata/client.py
@@ -123,6 +123,10 @@ class Client:
             self.session.get = self._get_with_sas
             self.session.head = self._head_with_sas
 
+    @property
+    def url(self):
+        return self.source.url
+
     def _download(
         self,
         request: Optional[dict] = None,

--- a/ecmwf/opendata/client.py
+++ b/ecmwf/opendata/client.py
@@ -13,10 +13,11 @@ import itertools
 import json
 import logging
 import os
-from collections import defaultdict
-
 import requests
+
+from collections import defaultdict
 from multiurl import download, robust
+from typing import Optional
 
 from .date import (
     canonical_time,
@@ -26,7 +27,9 @@ from .date import (
     expand_time,
     full_date,
 )
-from .urls import URLS
+from .sources import source_factory
+from .utils import warning_once, _show_attribution_message
+
 
 LOG = logging.getLogger(__name__)
 
@@ -43,63 +46,6 @@ MONTHLY_PATTERN = (
 PATTERNS = {"mmsa": MONTHLY_PATTERN}
 EXTENSIONS = {"tf": "bufr"}
 
-ONCE = set()
-
-_ATTRIBUTION_SHOWN = False  # module-level guard to avoid spamming
-
-
-def _show_attribution_message():
-    global _ATTRIBUTION_SHOWN
-    if not _ATTRIBUTION_SHOWN:
-        print(
-            "By downloading data from the ECMWF open data dataset, you agree to "
-            "the terms: Attribution 4.0 International (CC BY 4.0). Please "
-            "attribute ECMWF when downloading this data."
-        )
-        _ATTRIBUTION_SHOWN = True
-
-
-def warning_once(*args, did_you_mean=None):
-    if repr(args) in ONCE:
-        return
-
-    LOG.warning(*args)
-
-    ONCE.add(repr(args))
-
-    if did_you_mean:
-        words, vocabulary = did_you_mean
-
-        def levenshtein(a, b):
-            if len(a) == 0:
-                return len(b)
-
-            if len(b) == 0:
-                return len(a)
-
-            if a[0].lower() == b[0].lower():
-                return levenshtein(a[1:], b[1:])
-
-            return 1 + min(
-                [
-                    levenshtein(a[1:], b[1:]),
-                    levenshtein(a[1:], b),
-                    levenshtein(a, b[1:]),
-                ]
-            )
-
-        if not isinstance(words, (list, tuple)):
-            words = [words]
-
-        for word in words:
-            distance, best = min((levenshtein(word, w), w) for w in vocabulary)
-            if distance < min(len(word), len(best)):
-                LOG.warning(
-                    "Did you mean %r instead of %r?",
-                    best,
-                    word,
-                )
-
 
 class Result:
     def __init__(self, urls, target, dates, for_urls, for_index):
@@ -111,6 +57,7 @@ class Result:
             self.datetime = dates
         self.for_urls = for_urls
         self.for_index = for_index
+        self.size = None
 
 
 class Client:
@@ -127,9 +74,14 @@ class Client:
         use_sas_token=None,
         sas_known_key="ecmwf",
         sas_custom_url=None,
+        source_accept_ranges=None,
+        source_accept_multiple_ranges=None
     ):
-        self._url = None
-        self.source = source
+        self.source = source_factory(
+            name=source,
+            accept_ranges=source_accept_ranges,
+            accept_multiple_ranges=source_accept_multiple_ranges
+        )
         self.model = model
         self.resol = resol
         self.beta = beta
@@ -171,52 +123,33 @@ class Client:
             self.session.get = self._get_with_sas
             self.session.head = self._head_with_sas
 
-    @property
-    def url(self):
-        if self._url is None:
-            if self.source.startswith("http://") or self.source.startswith("https://"):
-                self._url = self.source
-            else:
-                if self.source not in URLS:
-                    warning_once(
-                        "Unknown source %r. Known sources are %r",
-                        self.source,
-                        list(URLS.keys()),
-                        did_you_mean=(self.source, list(URLS.keys())),
-                    )
-                    raise ValueError("Unknown source %r" % (self.source,))
-                self._url = URLS[self.source]
+    def _download(
+        self,
+        request: Optional[dict] = None,
+        target: Optional[str] = None,
+        use_index: bool = False,
+        **kwargs
+    ) -> Result:
+        result = self._get_urls(request, target=target, use_index=use_index, **kwargs)
+        if self.use_sas_token:
+            result.urls = self._apply_sas_to_urls(result.urls)
 
-        return self._url
+        result.size = download(
+            result.urls,
+            target=result.target,
+            verify=self.verify,
+            session=self.session,
+            accept_ranges=self.source.accept_ranges,
+            accept_multiple_ranges=self.source.accept_multiple_ranges
+        )
+        _show_attribution_message()
+        return result
 
     def retrieve(self, request=None, target=None, **kwargs):
-        result = self._get_urls(request, target=target, use_index=True, **kwargs)
-
-        if self.use_sas_token:
-            result.urls = self._apply_sas_to_urls(result.urls)
-        result.size = download(
-            result.urls,
-            target=result.target,
-            verify=self.verify,
-            session=self.session,
-        )
-        _show_attribution_message()
-        return result
+        return self._download(request, target=target, use_index=True, **kwargs)
 
     def download(self, request=None, target=None, **kwargs):
-        result = self._get_urls(request, target=target, use_index=False, **kwargs)
-
-        if self.use_sas_token:
-            result.urls = self._apply_sas_to_urls(result.urls)
-
-        result.size = download(
-            result.urls,
-            target=result.target,
-            verify=self.verify,
-            session=self.session,
-        )
-        _show_attribution_message()
-        return result
+        return self._download(request, target=target, use_index=False, **kwargs)
 
     def latest(self, request=None, **kwargs):
         if request is None:
@@ -265,7 +198,7 @@ class Client:
 
         for_urls, for_index = self.prepare_request(params)
 
-        for_urls["_url"] = [self.url]
+        for_urls["_url"] = [self.source.url]
 
         seen = set()
         data_urls = []

--- a/ecmwf/opendata/sources.py
+++ b/ecmwf/opendata/sources.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import Optional
+from .urls import URLS
+from .utils import warning_once
+
+
+@dataclass
+class Source:
+    url: str
+    name: Optional[str] = None
+    accept_ranges: Optional[bool] = None
+    accept_multiple_ranges: Optional[bool] = None
+
+
+def source_factory(
+    name: str,
+    accept_ranges: Optional[bool],
+    accept_multiple_ranges: Optional[bool]
+) -> Source:
+    """Create a Source instance for the given name or URL.
+
+    Parameters
+    ----------
+    name : str
+        A known source name (e.g. ``"aws"``, ``"azure"``, ``"google"``,
+        ``"ecmwf"``) or a full HTTP/HTTPS URL.
+    accept_ranges : bool, optional
+        Override whether the source supports HTTP range requests.
+        ``None`` lets the source infer support from response headers.
+    accept_multiple_ranges : bool, optional
+        Override whether the source supports multiple byte-range requests
+        in a single request. ``None`` lets the source infer support from
+        response headers.
+
+    Returns
+    -------
+    Source
+        A :class:`Source` dataclass populated with the resolved URL and
+        range settings.
+
+    Raises
+    ------
+    ValueError
+        If `name` is neither a known source name nor an HTTP/HTTPS URL.
+    """
+    if name in URLS.keys():
+        url = URLS[name]
+        # special case: cloud storages do not allow for multiple ranges
+        if name in ["aws", "azure", "google"]:
+            source = Source(
+                name=name,
+                url=url,
+                accept_ranges=True,
+                accept_multiple_ranges=False
+            )
+
+        # standard case: multiurl infers range request support from response headers
+        else:
+            source = Source(name=name, url=url)
+
+    # special case: provided name is an url
+    elif name.startswith("http://") or name.startswith("https://"):
+        warning_once(
+            "Unknown source %r. Known sources are %r",
+            name,
+            list(URLS.keys()),
+            did_you_mean=(name, list(URLS.keys())),
+        )
+        source = Source(url=name)
+    else:
+        raise ValueError("Unknown source %r" % (name,))
+
+    # override range settings if set
+    if accept_ranges is not None:
+        source.accept_ranges = accept_ranges
+    if accept_multiple_ranges is not None:
+        source.accept_multiple_ranges = accept_multiple_ranges
+    return source

--- a/ecmwf/opendata/sources.py
+++ b/ecmwf/opendata/sources.py
@@ -58,14 +58,8 @@ def source_factory(
         else:
             source = Source(name=name, url=url)
 
-    # special case: provided name is an url
+    # special case: provided name is a custom url
     elif name.startswith("http://") or name.startswith("https://"):
-        warning_once(
-            "Unknown source %r. Known sources are %r",
-            name,
-            list(URLS.keys()),
-            did_you_mean=(name, list(URLS.keys())),
-        )
         source = Source(url=name)
     else:
         raise ValueError("Unknown source %r" % (name,))

--- a/ecmwf/opendata/sources.py
+++ b/ecmwf/opendata/sources.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
+
 from .urls import URLS
-from .utils import warning_once
 
 
 @dataclass
@@ -13,9 +13,7 @@ class Source:
 
 
 def source_factory(
-    name: str,
-    accept_ranges: Optional[bool],
-    accept_multiple_ranges: Optional[bool]
+    name: str, accept_ranges: Optional[bool], accept_multiple_ranges: Optional[bool]
 ) -> Source:
     """Create a Source instance for the given name or URL.
 
@@ -48,10 +46,7 @@ def source_factory(
         # special case: cloud storages do not allow for multiple ranges
         if name in ["aws", "azure", "google"]:
             source = Source(
-                name=name,
-                url=url,
-                accept_ranges=True,
-                accept_multiple_ranges=False
+                name=name, url=url, accept_ranges=True, accept_multiple_ranges=False
             )
 
         # standard case: multiurl infers range request support from response headers

--- a/ecmwf/opendata/urls.py
+++ b/ecmwf/opendata/urls.py
@@ -14,12 +14,12 @@ import os
 DOT_ECMWF_OPENDATA = os.path.expanduser("~/.ecmwf-opendata")
 
 URLS = {
-    "ecmwf": "https://data.ecmwf.int/forecasts",
-    "azure": "https://ai4edataeuwest.blob.core.windows.net/ecmwf",
     "aws": "https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com",
+    "azure": "https://ai4edataeuwest.blob.core.windows.net/ecmwf",
+    "ecmwf": "https://data.ecmwf.int/forecasts",
     "ecmwf-esuites": "https://xdiss.ecmwf.int/ecpds/home/opendata",
-    "google": "https://storage.googleapis.com/ecmwf-open-data",
     "ecmwf-testdata": "https://data.ecmwf.int/forecasts/testdata",
+    "google": "https://storage.googleapis.com/ecmwf-open-data",
 }
 
 if os.path.exists(DOT_ECMWF_OPENDATA):

--- a/ecmwf/opendata/utils.py
+++ b/ecmwf/opendata/utils.py
@@ -1,0 +1,60 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
+ONCE = set()
+
+_ATTRIBUTION_SHOWN = False  # module-level guard to avoid spamming
+
+
+def _show_attribution_message():
+    global _ATTRIBUTION_SHOWN
+    if not _ATTRIBUTION_SHOWN:
+        print(
+            "By downloading data from the ECMWF open data dataset, you agree to "
+            "the terms: Attribution 4.0 International (CC BY 4.0). Please "
+            "attribute ECMWF when downloading this data."
+        )
+        _ATTRIBUTION_SHOWN = True
+
+
+def warning_once(*args, did_you_mean=None):
+    if repr(args) in ONCE:
+        return
+
+    LOG.warning(*args)
+
+    ONCE.add(repr(args))
+
+    if did_you_mean:
+        words, vocabulary = did_you_mean
+
+        def levenshtein(a, b):
+            if len(a) == 0:
+                return len(b)
+
+            if len(b) == 0:
+                return len(a)
+
+            if a[0].lower() == b[0].lower():
+                return levenshtein(a[1:], b[1:])
+
+            return 1 + min(
+                [
+                    levenshtein(a[1:], b[1:]),
+                    levenshtein(a[1:], b),
+                    levenshtein(a, b[1:]),
+                ]
+            )
+
+        if not isinstance(words, (list, tuple)):
+            words = [words]
+
+        for word in words:
+            distance, best = min((levenshtein(word, w), w) for w in vocabulary)
+            if distance < min(len(word), len(best)):
+                LOG.warning(
+                    "Did you mean %r instead of %r?",
+                    best,
+                    word,
+                )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     url="https://github.com/ecmwf/ecmwf-opendata",
     packages=setuptools.find_namespace_packages(include=["ecmwf.*"]),
     include_package_data=True,
-    install_requires=["multiurl>=0.2.1"],
+    install_requires=["multiurl>=0.3.8"],
     zip_safe=True,
     keywords="tool",
     classifiers=[

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -41,10 +41,6 @@ def xxx_test_sources_2(source):
 
 @pytest.mark.parametrize("source", SOURCES)
 def test_sources_3(source):
-    if source == "google":
-        pytest.skip(
-            "Skipping test on google source due to known issue of multiple indexes not allowed on google"
-        )
     client = Client(source)
     client.retrieve(
         time=0,
@@ -74,10 +70,6 @@ def xxx_test_sources_4(source):
 @pytest.mark.parametrize("source", SOURCES)
 def test_sources_6(source):
     client = Client(source)
-    if source == "google":
-        pytest.skip(
-            "Skipping test on google source due to known issue of multiple indexes not allowed on google"
-        )
     client.retrieve(
         time=0,
         stream="enfo",

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ecmwf.opendata import Client
 
 
@@ -56,6 +58,7 @@ def test_stream_legacy():
     assert patch_stream("scwv", 18, "ep") == "waef"
 
 
+@pytest.mark.skip(reason="ecmwf-testdata source is no longer available")
 def test_stream_50r1():
     """IFS Cycle 50r1 behaviour (source='ecmwf-testdata'): 06/18 UTC runs remain
     under stream=oper/wave, with no scda/scwv streams."""


### PR DESCRIPTION
### Description
This PR introduces the `Source` dataclass, which is created via `source_factory`. It consolidates source configuration into a single entity and makes it possible to define default range-request settings. For cloud storage, multiple range requests are disabled by default to address https://github.com/ecmwf/ecmwf-opendata/issues/94. The PR also includes minor code refactors to improve readability.

This PR depends on the changes in `multiurl` introduced by https://github.com/ecmwf/multiurl/pull/46

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
