### PR TITLE
fix: dont override explicit model by class

### DIFF
--- a/ecmwf/opendata/__init__.py
+++ b/ecmwf/opendata/__init__.py
@@ -10,6 +10,6 @@
 
 from .client import Client
 
-__version__ = "0.3.30"
+__version__ = "0.3.31"
 
 __all__ = ["Client"]

--- a/ecmwf/opendata/client.py
+++ b/ecmwf/opendata/client.py
@@ -341,9 +341,10 @@ class Client:
         else:
             params = dict(**request)
 
-        # If model is in the retireve overwrite the client model
-        # Warn user if client model does not match the model in retrieve
         if "model" in params:
+            # If model is in the retireve overwrite the client model
+            # Warn user if client model does not match the model in retrieve
+            # Takes precedence over class-based model derivation
             if self.model != params["model"]:
                 warning_once(
                     "Model %r does not match the client model %r, using model %r from retrieve",
@@ -353,13 +354,23 @@ class Client:
                     did_you_mean=(params["model"], self.model),
                 )
             model = params["model"]
-        else:
-            model = self.model
-
-        if "class" in params:
+        elif "class" in params:
+            # If model is implied by class, overwrite the client model
+            # Warn user if client model does not match the model from class
             model = {"od": "ifs", "ai": "aifs-single", "aifs-ens": "aifs-ens"}[
                 params["class"]
             ]
+            if self.model != model:
+                warning_once(
+                    "Model %r derived from class %r does not match the client model %r, using model %r",
+                    model,
+                    params["class"],
+                    self.model,
+                    model,
+                    did_you_mean=(model, self.model),
+                )
+        else:
+            model = self.model
 
         # Default stream for aifs-ens is enfo as this model only has ensemble forecasts
         if model == "aifs-ens":

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -25,5 +25,28 @@ def test_request():
     assert for_urls["date"] == [str(s) for s in range(20000101, 20000132, 7)]
 
 
+def test_explicit_model_not_overridden_by_class():
+    """Test that an explicit model in retrieve takes precedence over class-derived model.
+
+    Previously passing model="aifs-ens" with class="od" would prevent the automatic stream="enfo"
+    default from being applied because class="od" would override model to "ifs".
+    """
+    client = Client(model="ifs")
+
+    # Explicit model="aifs-ens" should trigger stream="enfo" default,
+    # even when class="od" (which maps to "ifs") is also provided.
+    for_urls, _ = client.prepare_request(model="aifs-ens", **{"class": "od"})
+    assert for_urls["model"] == ["aifs-ens"]
+    assert for_urls["stream"] == ["enfo"]
+
+    # When only class is provided (no explicit model), class should derive the model
+    for_urls, _ = client.prepare_request(**{"class": "ai"})
+    assert for_urls["model"] == ["aifs-single"]
+
+    # When neither model nor class is provided, client default should be used
+    for_urls, _ = client.prepare_request(step=0)
+    assert for_urls["model"] == ["ifs"]
+
+
 if __name__ == "__main__":
     test_request()


### PR DESCRIPTION
When retrieving from opendata with model being aifs-enfs and class ai, the client replaces the model by aifs-single, leading to url not being found.

We change the internal logic of "if class is given, use it to derive the model no matter what" to "if class is given and model is *not* explicitly given, derive model from class, otherwise respect explicitly given model".

We additionally add a warning when the class-derived model differs from the client-constructed model, increasing consistency with explicit model vs client-constructed model mismatch.
